### PR TITLE
Gajendra mahato/acceptance

### DIFF
--- a/acceptance/GajendraMahato/bash_port_scanner.sh
+++ b/acceptance/GajendraMahato/bash_port_scanner.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Check if a hostname is provided
+if [ -z "$1" ]; then
+    {
+    echo "Usage: $0 [host]"
+    echo "Scan ports on the specified non-SSL host."
+    echo
+    echo "Example:"
+    echo "  $0 127.0.0.1"
+    exit 1
+}
+fi
+
+host=$1  # Assign the provided hostname to a variable
+
+# Perform the scan
+echo -e "Scanning ports on $host\n"
+hostname=$1  # Assign the provided hostname to a variable
+for port in {1..65535}; do 
+    if ncat -zw1 $hostname $port ; then  # Attempt to connect to the port using SSL
+        echo "Discovered open port $port/tcp on $hostname"
+    fi
+done

--- a/acceptance/GajendraMahato/bash_port_scanner.sh
+++ b/acceptance/GajendraMahato/bash_port_scanner.sh
@@ -18,7 +18,7 @@ host=$1  # Assign the provided hostname to a variable
 echo -e "Scanning ports on $host\n"
 hostname=$1  # Assign the provided hostname to a variable
 for port in {1..65535}; do 
-    if ncat -zw1 $hostname $port ; then  # Attempt to connect to the port using SSL
+    if nc -zw1 $hostname $port ; then  # Attempt to connect to the port using SSL
         echo "Discovered open port $port/tcp on $hostname"
     fi
 done


### PR DESCRIPTION
### Description of Bash Port Scanner Script

I have created a Bash script that preform a port scanning specifically designed for non-SSL (non-encrypted) sites. This script allows users to specify a hostname or IP address as the first argument when executing the script.

### Usage

- To use this script, provide a hostname or IP address as the first argument when executing the script. For example:
  ```bash
  ./port_scanner.sh 127.0.0.1
  ```
  Replace `127.0.0.1` with the hostname or IP address of the target non-SSL site you want to scan for open ports.
